### PR TITLE
Fix/null handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>dev.archimedes</groupId>
     <artifactId>excel4j</artifactId>
-    <version>0.0.7-SNAPSHOT</version>
+    <version>0.0.8-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/src/main/java/dev/archimedes/excel4j/resolvers/TypeResolver.java
+++ b/src/main/java/dev/archimedes/excel4j/resolvers/TypeResolver.java
@@ -87,6 +87,12 @@ public class TypeResolver {
     }
 
     public static <T> void resolveList(T instance, Field field, Cell cell, ExcelOption<T> option) throws IllegalAccessException {
+
+        if(StringUtil.isBlank(cell.toString())) {
+            field.set(instance, null);
+            return;
+        }
+
         Type genericType = field.getGenericType();
         if(genericType instanceof ParameterizedType parameterizedType){
             Type actualTypeArgument = parameterizedType.getActualTypeArguments()[0];


### PR DESCRIPTION
This pull request includes updates to the `pom.xml` file and improvements to the `resolveList` method in the `TypeResolver` class. The most important changes are:

Version Update:
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L9-R9): Updated the project version from `0.0.7-SNAPSHOT` to `0.0.8-SNAPSHOT`.

Code Enhancement:
* [`src/main/java/dev/archimedes/excel4j/resolvers/TypeResolver.java`](diffhunk://#diff-dd516be42da873d1f552d502ca106c8c076e5d9333965ebd52ec796f6c0c9384R90-R95): Added a check in the `resolveList` method to set the field to `null` if the cell content is blank, improving the handling of empty cells.